### PR TITLE
Persistent Login

### DIFF
--- a/__main__.py
+++ b/__main__.py
@@ -1,4 +1,7 @@
 from interfaces.cli import EmsShell
+from models.admin import Admin
 
 if __name__ == '__main__':
+    Admin.configure_initial_user()
+
     EmsShell().cmdloop()

--- a/controller/admin_controller.py
+++ b/controller/admin_controller.py
@@ -3,10 +3,6 @@ from models.user import User
 ###---- Admin Menu ----
 def view_admin_profile(user: User) -> str:
     """
-    Dennis
+    Print information about the user.
     """
-    pass
-
-
-
-
+    return str(user)

--- a/controller/tests/test_admin_controller.py
+++ b/controller/tests/test_admin_controller.py
@@ -1,0 +1,21 @@
+import unittest
+
+from controller.admin_controller import view_admin_profile
+from models.admin import Admin
+
+
+class AdminControllerTest(unittest.TestCase):
+
+    def setUp(self) -> None:
+        Admin.delete_all()
+
+    def test_profile(self):
+        user = Admin('test_user', 'test_password')
+        self.assertEqual(str(user), view_admin_profile(user))
+
+    def tearDown(self) -> None:
+        Admin.delete_all()
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/data/users.py
+++ b/data/users.py
@@ -1,6 +1,0 @@
-from models.admin import Admin
-
-root_user = Admin('root', 'root')
-users_catalog = {
-    root_user.username: root_user
-}

--- a/interfaces/cli.py
+++ b/interfaces/cli.py
@@ -1,6 +1,7 @@
 from cmd import Cmd
 
-from models.user import User
+from models.admin import Admin
+from models.user import User, require_role
 
 
 class EmsShell(Cmd):
@@ -62,3 +63,6 @@ class EmsShell(Cmd):
         print(f'username: {self.user.username}\n'
               f'role: {self.user.__class__.__name__}')
 
+    @require_role(Admin)
+    def do_sudo(self, arg):
+        print('Admin access verified')

--- a/interfaces/cli.py
+++ b/interfaces/cli.py
@@ -60,10 +60,7 @@ class EmsShell(Cmd):
         """
         Print user info
         """
-        print(f'username: {self.user.username}\n'
-              f'role: {self.user.__class__.__name__}')
-        if self.user.__class__.__name__ == 'Volunteer':
-            print(self.user)
+        print(self.user)
 
     @require_role(Admin)
     def do_sudo(self, arg):

--- a/interfaces/cli.py
+++ b/interfaces/cli.py
@@ -1,6 +1,5 @@
 from cmd import Cmd
 
-from data.users import users_catalog
 from models.user import User
 
 
@@ -20,11 +19,15 @@ class EmsShell(Cmd):
             username = input('Username: ')
             password = input('Password: ')
             try:
-                self.user = users_catalog[username].login(password)
+                user = User.find(username)
+                if not user:
+                    print('User not found')
+                    continue
+                self.user = user.login(password)
                 self.prompt = f'{self.user.username}> '
                 print(f'Welcome {self.user.username}')
-            except (KeyError, User.InvalidPassword):
-                print('Invalid username or password. Please try again.')
+            except User.InvalidPassword:
+                print('Invalid password. Please try again.')
 
     def do_logout(self, args):
         """

--- a/interfaces/cli.py
+++ b/interfaces/cli.py
@@ -1,7 +1,6 @@
 from cmd import Cmd
 
-from models.admin import Admin
-from models.user import User, require_role
+from models.user import User
 
 
 class EmsShell(Cmd):
@@ -61,7 +60,3 @@ class EmsShell(Cmd):
         Print user info
         """
         print(self.user)
-
-    @require_role(Admin)
-    def do_sudo(self, arg):
-        print('Admin access verified')

--- a/interfaces/cli.py
+++ b/interfaces/cli.py
@@ -62,6 +62,8 @@ class EmsShell(Cmd):
         """
         print(f'username: {self.user.username}\n'
               f'role: {self.user.__class__.__name__}')
+        if self.user.__class__.__name__ == 'Volunteer':
+            print(self.user)
 
     @require_role(Admin)
     def do_sudo(self, arg):

--- a/models/admin.py
+++ b/models/admin.py
@@ -5,4 +5,11 @@ class Admin(User):
     """
     Class for admin user
     """
-    pass
+
+    @classmethod
+    def configure_initial_user(cls):
+        """
+        Configure initial admin user if no admin exists
+        """
+        if len(cls.all()) == 0:
+            cls('root', 'root')

--- a/models/base/document.py
+++ b/models/base/document.py
@@ -2,9 +2,10 @@ from __future__ import annotations
 
 import os
 import pickle
+import sys
 from typing import Union
 
-from models.base.field import ReferenceDocumentsField
+from models.base.field import ReferenceDocumentsField, ReferenceSet
 from models.base.meta_document import MetaDocument, MetaIndexedDocument
 
 
@@ -93,10 +94,35 @@ class Document(metaclass=MetaDocument):
 
     def save(self) -> None:
         """
+        Save all documents associated with this document.
+        """
+        self._persist()
+        self._save_referrers()  # Recursively look for root level documents and save them.
+        self._save_referees()  # Also save all documents that this document references.
+
+    def _persist(self) -> None:
+        """
+        By default, documents are not persisted. To be overridden by subclasses.
+        """
+        return
+
+    def _save_referrers(self) -> None:
+        """
         Recursively call save on the root-level document
         """
         for referrer in self._referenced_by:
-            referrer.save()
+            referrer._persist()
+            referrer._save_referrers()
+
+    def _save_referees(self) -> None:
+        """
+        Recursively save all referees.
+        """
+        for field_name, field in self._fields.items():
+            if isinstance(field, ReferenceDocumentsField):
+                for referee in getattr(self, field_name):
+                    referee._persist()
+                    referee._save_referees()
 
     def delete(self) -> None:
         """
@@ -132,13 +158,13 @@ class Document(metaclass=MetaDocument):
     def __eq__(self, other):
         return self._data == other._data
 
-    def _add_referrer(self, referer):
-        if referer not in self._referenced_by:
-            self._referenced_by.append(referer)
+    def _add_referrer(self, referrer):
+        if referrer not in self._referenced_by:
+            self._referenced_by.append(referrer)
 
-    def _remove_referrer(self, referer):
-        if referer in self._referenced_by:
-            self._referenced_by.remove(referer)
+    def _remove_referrer(self, referrer):
+        if referrer in self._referenced_by:
+            self._referenced_by.remove(referrer)
 
     def __unlink_referee(self, referee):
         for field_name, field in self._fields.items():
@@ -148,8 +174,32 @@ class Document(metaclass=MetaDocument):
                     documents.remove(referee)
         self.save()
 
+    def _get_root_document(self):
+        """
+        Get the root-level document.
+        """
+        for referrer in self._referenced_by:
+            root = referrer._get_root_document()
+            if root is not None:
+                return root
+
     def __str__(self):
         return f'{self.__class__.__name__}({self._data})'
+
+    def __getstate__(self):
+        """
+        Customise pickling: referrers are not pickled to avoid circular references.
+        Instead, root-level documents of the referrers are marked and loaded while unpickling.
+        referrer pointers are relinked by loading the referrer indices.
+        """
+        state = self.__dict__.copy()
+        referrer_roots = set()
+        for referrer in self._referenced_by:
+            root = referrer._get_root_document()
+            referrer_roots.add((root.__module__, root.__class__.__name__))
+        state['_referrer_roots'] = referrer_roots
+        state['_referenced_by'] = []
+        return state
 
 
 class IndexedDocument(Document, metaclass=MetaIndexedDocument):
@@ -162,6 +212,51 @@ class IndexedDocument(Document, metaclass=MetaIndexedDocument):
     The default persistence path is data/{classname}
     to change the path, override the _persistence_path property.
     """
+
+    __objects = None
+
+    class Pickler(pickle.Pickler):
+        """
+        Custom pickler to persist references to other IndexedDocuments.
+        """
+
+        def __init__(self, file, base_class):
+            super().__init__(file)
+            self.base_class = base_class
+
+        def persistent_id(self, obj):
+            if not isinstance(obj, self.base_class) and isinstance(obj, IndexedDocument):
+                return obj.__module__, obj.__class__.__name__, obj.key
+            else:
+                return None
+
+    class Unpickler(pickle.Unpickler):
+        """
+        Custom unpickler to restore references to other IndexedDocuments.
+        """
+
+        def persistent_load(self, pid):
+            module, classname, key = pid
+            return IndexedDocument.DeferredReference(module, classname, key)
+
+    class DeferredReference:
+        """
+        A reference to an IndexedDocument that is not yet loaded to avoid circular references.
+        These are restored after loading the whole index.
+        """
+
+        def __init__(self, module, classname, key):
+            self.module = module
+            self.classname = classname
+            self.key = key
+
+        def restore(self):
+            """
+            Restore the referenced document.
+            """
+            __import__(self.module)
+            index = getattr(sys.modules[self.module], self.classname)
+            return index.find(self.key)
 
     def __init__(self, **kwargs):
         self.__class__.check_and_load_data()
@@ -176,36 +271,76 @@ class IndexedDocument(Document, metaclass=MetaIndexedDocument):
         """
         try:
             with open(cls._persistence_path, 'rb') as f:
-                cls.__objects = pickle.load(f)
+                cls.__objects = cls.Unpickler(f).load()
+                for key in cls.__objects:
+                    # Restore deferred references to referees
+                    cls.__objects[key] = cls.__restore_reference(cls.__objects[key])
+                    # Load all indices referring to this document to relink referrers
+                    cls.__restore_referrer(cls.__objects[key])
         except FileNotFoundError:
             cls.__objects = {}
+
+    @classmethod
+    def __restore_reference(cls, value):
+        """
+        Restore deferred references to other IndexedDocuments recursively.
+        :param value: a DeferredReference, Document, ReferenceSet, or field value
+        :return: the restored value, or None if it was a field value
+        """
+        if isinstance(value, cls.DeferredReference):
+            return value.restore()
+        elif isinstance(value, Document):
+            for field_name, field in value._fields.items():
+                restored_field = cls.__restore_reference(getattr(value, field_name))
+                if restored_field is not None:
+                    setattr(value, field_name, restored_field)
+            return value
+        elif isinstance(value, ReferenceSet):
+            return [cls.__restore_reference(doc) for doc in value]
+        else:
+            return None
+
+    @classmethod
+    def __restore_referrer(cls, obj) -> None:
+        """
+        Load all indices referring to this document to relink referrers.
+        :param obj: an unpickled IndexedDocument instance
+        """
+        if getattr(obj, '_referrer_roots', None):
+            for mod, classname in obj._referrer_roots:
+                __import__(mod)
+                index = getattr(sys.modules[mod], classname)
+                index.check_and_load_data()
+            delattr(obj, '_referrer_roots')
 
     @classmethod
     def check_and_load_data(cls):
         """
         Check if the index is loaded, if not, load it.
         """
-        if not getattr(cls, '__objects', None):
+        if not cls.__objects:
             cls.reload()
 
-    def save(self) -> None:
+    def _persist(self) -> None:
         """
         Save all documents of the same type (i.e. the index) to disk.
-        Also save all root-level documents referencing this document.
+        If the class is a subclass of IndexedDocument, also persist to parent indices.
         """
         self.__class__.check_and_load_data()
         self.__class__.__objects[self.key] = self
         os.makedirs(os.path.dirname(self._persistence_path), exist_ok=True)
         with open(self._persistence_path, 'wb') as f:
-            pickle.dump(self.__class__.__objects, f)
+            self.Pickler(f, self.__class__).dump(self.__class__.__objects)
 
         # Also save to parent indices
         for persistence_base in self._persistence_bases:
-            persistence_base.__save_child(self)
-        super().save()
+            persistence_base.__index_subclass(self)
+
+    def _get_root_document(self):
+        return self
 
     @classmethod
-    def __save_child(cls, child: Document) -> None:
+    def __index_subclass(cls, child: Document) -> None:
         """
         Save a child document to the parent index.
         to be called from subclass.

--- a/models/base/document.py
+++ b/models/base/document.py
@@ -345,8 +345,9 @@ class IndexedDocument(Document, metaclass=MetaIndexedDocument):
     @classmethod
     def __index_subclass(cls, child: Document) -> None:
         """
-        Save a child document to the parent index.
-        to be called from subclass.
+        Save a subclass instance to the index of the parent (this) class.
+        To be called from the _persist method of a subclass of another IndexedDocument,
+        such as to replace instances in the index of the parent class with instances of the subclass.
         :param child: child instance to be saved
         """
         cls.check_and_load_data()

--- a/models/base/document.py
+++ b/models/base/document.py
@@ -164,7 +164,7 @@ class IndexedDocument(Document, metaclass=MetaIndexedDocument):
     """
 
     def __init__(self, **kwargs):
-        self.reload()
+        self.__class__.check_and_load_data()
         if not self._primary_key:
             raise Document.PrimaryKeyNotDefinedError(self)
         super().__init__(**kwargs)

--- a/models/base/document.py
+++ b/models/base/document.py
@@ -156,6 +156,8 @@ class Document(metaclass=MetaDocument):
         raise self.ReferrerNotFound(referrer_type, field_name)
 
     def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return False
         return self._data == other._data
 
     def _add_referrer(self, referrer):

--- a/models/tests/test_volunteer.py
+++ b/models/tests/test_volunteer.py
@@ -4,15 +4,19 @@ from models.volunteer import Volunteer
 
 class TestVolunteer(unittest.TestCase):
 
+    def setUp(self):
+        Volunteer.delete_all()
+
     def test_create_volunteer(self):
         volunteer = Volunteer(username='yunsy', password='root', firstname='Yunsy', lastname='Yin',
                               phone='+447519953189')
         self.assertIsInstance(volunteer, Volunteer)
 
     def test_delete_volunteer(self):
-        volunteer = Volunteer.find('yunsy')
+        volunteer = Volunteer(username='peter', password='1234', firstname='Peter', lastname='Green',
+                              phone='+447519953189')
         volunteer.delete()
-        self.assertIsNone(Volunteer.find('yunsy'))
+        self.assertIsNone(Volunteer.find('peter'))
 
     def test_deactivate_volunteer(self):
         volunteer = Volunteer(username='yunsy', password='root', firstname='Yunsy', lastname='Yin',
@@ -58,6 +62,5 @@ class TestVolunteer(unittest.TestCase):
             Volunteer(username='yunsy', password='root', firstname='Yunsy', lastname='Yin',
                       phone='+12345')
 
-
-if __name__ == '__main__':
-    unittest.main()
+    def tearDown(self) -> None:
+        Volunteer.delete_all()

--- a/models/user.py
+++ b/models/user.py
@@ -44,6 +44,13 @@ class User(IndexedDocument):
     def update_password(self, password: str) -> None:
         self.__password_hash = self.__hash_password(password, self.__salt)
 
+    def __repr__(self):
+        return f"<{self.__class__.__name__} '{self.username}'>"
+
+    def __str__(self):
+        return f'Username: {self.username}\n' \
+               f'Role: {self.__class__.__name__}'
+
 
 def require_role(*roles: type):
     """

--- a/models/user.py
+++ b/models/user.py
@@ -16,11 +16,11 @@ class User(IndexedDocument):
     __salt = Field()
     __password_hash = Field()
 
-    def __init__(self, username: str, password: str):
+    def __init__(self, username: str, password: str, **kwargs):
         salt = os.urandom(32)
         super().__init__(username=username,
                          _User__salt=salt,
-                         _User__password_hash=self.__hash_password(password, salt))
+                         _User__password_hash=self.__hash_password(password, salt), **kwargs)
 
     @staticmethod
     def __hash_password(password: str, salt: bytes) -> bytes:

--- a/models/volunteer.py
+++ b/models/volunteer.py
@@ -1,13 +1,12 @@
 import datetime
 import re
 
-from models.base.document import IndexedDocument
+from models.base.document import IndexedDocument, Document
 from models.base.field import Field
+from models.user import User
 
 
-class Volunteer(IndexedDocument):
-    username = Field(primary_key=True)
-    password = Field()
+class Volunteer(User):
     account_activated = Field()
     firstname = Field()
     lastname = Field()
@@ -83,9 +82,13 @@ class Volunteer(IndexedDocument):
         return self.find_referred_by(referrer_type=Camp)
 
     def __str__(self):
+        try:
+            camp_str = f'belongs to camp {self.camp}'
+        except Document.ReferrerNotFound:
+            camp_str = 'does not belong to any camp'
         return f"Volunteer username: {self.username}\n" \
                f"Account activated: {self.account_activated}\n" \
-               f"Volunteer {self.firstname} {self.lastname} belongs to camp {self.camp}.\n" \
+               f"Volunteer {self.firstname} {self.lastname} {camp_str}.\n" \
                f"Phone Number: {self.phone}\n" \
                f"Availability: {self.availability}\n" \
                f"Date joined: {self.__creation_date}\n"

--- a/models/volunteer.py
+++ b/models/volunteer.py
@@ -83,7 +83,7 @@ class Volunteer(User):
 
     def __str__(self):
         try:
-            camp_str = f'belongs to camp {self.camp}'
+            camp_str = f'belongs to camp {self.camp} under {self.camp.plan}'
         except Document.ReferrerNotFound:
             camp_str = 'does not belong to any camp'
         return f"Volunteer username: {self.username}\n" \

--- a/models/volunteer.py
+++ b/models/volunteer.py
@@ -83,12 +83,13 @@ class Volunteer(User):
 
     def __str__(self):
         try:
-            camp_str = f'belongs to camp {self.camp} under {self.camp.plan}'
+            camp_str = f'{self.camp} @ {self.camp.plan}'
         except Document.ReferrerNotFound:
-            camp_str = 'does not belong to any camp'
-        return f"Volunteer username: {self.username}\n" \
+            camp_str = 'not assigned'
+        return f"{super().__str__()}\n" \
                f"Account activated: {self.account_activated}\n" \
-               f"Volunteer {self.firstname} {self.lastname} {camp_str}.\n" \
+               f"Name: {self.firstname} {self.lastname}\n" \
+               f"Camp: {camp_str}\n" \
                f"Phone Number: {self.phone}\n" \
                f"Availability: {self.availability}\n" \
                f"Date joined: {self.__creation_date}\n"


### PR DESCRIPTION
# What to review

This PR implements a main feature (adapting login to the persistence model), but also introduces new changes to the persistence model, and fixed some bugs in it. 

Since the code for the later parts is quite long, I recommends only reviewing the main feature and skimming through the rest. 

## Main feature

This PR mainly adapted the current `Volunteer` class to be a subclass of `User`, so that once a user login, we can tell if they are a volunteer. 

Relevant changes: 
* `volunteer.py`: `Volunteer` is now a subclass of `User`
* `admin.py`: The original implementation of `user_catalog`is abandoned in favor for a document index
* `admin_contoller.py`: the admin profile controller method is implemented. 
* `cli.py`: The cli code is adapted to use `User.find` to retrieve the user. 
* `__main__.py`: code changed to initialise the first admin user

## Supporting change

To support this, the persistence base classes were changed to handle subclassing `IndexedDocuments`.
Specifically, when we create a subclass, it will also be written to the parent index, so that when we do `User.find`, we actually retrieve the child instance (`Volunteer` or `Admin`), instead of a abstract `User` instance. 

The change is mainly in `doument.py`:
* `__index_subclass` allows saving child instances, which is called in `_persist`

## Bug fix

While working on the feature, I found that the original code could not automatically link volunteers and camps while unpickling. Also, when you add or remove a volunteer from a camp, the change is only persisted on the camp/plan but not on the volunteer indexeddocument. 

A bulk of the changes in this commit is to fix these issues, including pickling and unpickling using custom Pickler/Unpickler, using a special class `DeferredReference` to avoid circular reference while reading, and recursively saving referees. 

Since these are bug fixes and the logic is quite convoluted, I suggest you to skip them unless you are curious. 

closes #30 