### PR TITLE
Fix that volunteer can still be found in User after being deleted

### DIFF
--- a/models/base/document.py
+++ b/models/base/document.py
@@ -268,6 +268,11 @@ class IndexedDocument(Document, metaclass=MetaIndexedDocument):
         super().__init__(**kwargs)
         self.__class__.__objects[self.key] = self
 
+        # Also save to parent indices
+        for persistence_base in self._persistence_bases:
+            persistence_base.__index_subclass_add(self)
+            persistence_base._persist()
+
     @classmethod
     def reload(cls) -> None:
         """
@@ -325,36 +330,41 @@ class IndexedDocument(Document, metaclass=MetaIndexedDocument):
         if cls.__objects is None:
             cls.reload()
 
-    def _persist(self) -> None:
+    @classmethod
+    def _persist(cls) -> None:
         """
         Save all documents of the same type (i.e. the index) to disk.
         If the class is a subclass of IndexedDocument, also persist to parent indices.
         """
-        self.__class__.check_and_load_data()
-        os.makedirs(os.path.dirname(self._persistence_path), exist_ok=True)
-        with open(self._persistence_path, 'wb') as f:
-            self.Pickler(f, self.__class__).dump(self.__class__.__objects)
-
-        # Also save to parent indices
-        for persistence_base in self._persistence_bases:
-            persistence_base.__index_subclass(self)
+        cls.check_and_load_data()
+        os.makedirs(os.path.dirname(cls._persistence_path), exist_ok=True)
+        with open(cls._persistence_path, 'wb') as f:
+            cls.Pickler(f, cls).dump(cls.__objects)
 
     def _get_root_document(self):
         return self
 
     @classmethod
-    def __index_subclass(cls, child: Document) -> None:
+    def __index_subclass_add(cls, child: Document) -> None:
         """
         Save a subclass instance to the index of the parent (this) class.
-        To be called from the _persist method of a subclass of another IndexedDocument,
+        To be called from the __init__ method of a subclass of another IndexedDocument,
         such as to replace instances in the index of the parent class with instances of the subclass.
-        :param child: child instance to be saved
+        :param child: child instance to be added
         """
         cls.check_and_load_data()
         cls.__objects[child.key] = child
-        os.makedirs(os.path.dirname(cls._persistence_path), exist_ok=True)
-        with open(cls._persistence_path, 'wb') as f:
-            pickle.dump(cls.__objects, f)
+
+
+    @classmethod
+    def __index_subclass_remove(cls, child: Document) -> None:
+        """
+        Remove a subclass instance from the index of the parent (this) class.
+        To be called from the delete method of a subclass of another IndexedDocument,
+        :param child: child instance to be deleted
+        """
+        cls.check_and_load_data()
+        del cls.__objects[child.key]
 
     @classmethod
     def find(cls, key) -> Union[None, IndexedDocument]:
@@ -382,6 +392,10 @@ class IndexedDocument(Document, metaclass=MetaIndexedDocument):
         self.__class__.check_and_load_data()
         del self.__class__.__objects[self.key]
         self._persist()
+        # Also save to parent indices
+        for persistence_base in self._persistence_bases:
+            persistence_base.__index_subclass_remove(self)
+            persistence_base._persist()
         super().delete()
 
     @classmethod

--- a/models/tests/test_volunteer.py
+++ b/models/tests/test_volunteer.py
@@ -1,4 +1,6 @@
 import unittest
+
+from models.user import User
 from models.volunteer import Volunteer
 
 
@@ -11,12 +13,14 @@ class TestVolunteer(unittest.TestCase):
         volunteer = Volunteer(username='yunsy', password='root', firstname='Yunsy', lastname='Yin',
                               phone='+447519953189')
         self.assertIsInstance(volunteer, Volunteer)
+        self.assertEqual(User.find('yunsy'), volunteer)
 
     def test_delete_volunteer(self):
         volunteer = Volunteer(username='peter', password='1234', firstname='Peter', lastname='Green',
                               phone='+447519953189')
         volunteer.delete()
         self.assertIsNone(Volunteer.find('peter'))
+        self.assertIsNone(User.find('peter'))
 
     def test_deactivate_volunteer(self):
         volunteer = Volunteer(username='yunsy', password='root', firstname='Yunsy', lastname='Yin',


### PR DESCRIPTION
Currently, if we delete a volunteer
```
volunteer = Volunteer(username='peter'...)
volunter.delete()
```
It can still be found in Users
```
user = Users.find('peter')
# user should be None but is Volunteer('peter'...)
```

This PR fixed this issue, and also added this check to the tests. 