### PR TITLE
Handling closed plans

### DIFF
--- a/controller/plan_controller.py
+++ b/controller/plan_controller.py
@@ -95,7 +95,7 @@ def close_plan(plan: Plan):
     Inputted plan will be changed to read-only by changing the __is_closed flag in Plan class.
     """
     if plan.is_closed:
-        raise controller_error.ControllerError("Plan is already closed.")
+        raise controller_error.ControllerError(f"Plan {plan.name} is already closed.")
     else:
         plan.close()
         plan.save()

--- a/controller/plan_controller.py
+++ b/controller/plan_controller.py
@@ -57,7 +57,12 @@ def view_plan_statistics(plan: Plan) -> str:
 
     plan_statistics = plan.statistics()
     plan_name = str(plan.name)
-    plan_info = f"\nPlan name: {plan_name}\n"
+    if plan.is_closed:
+        plan_info = f"\nPlan name: '{plan_name}' (closed)\n" \
+                    f"Close Date: '{plan.close_date}'\n"
+    else:
+        plan_info = f"\nPlan name: '{plan_name}'\n"
+
     statistics = ""
 
     for camp in plan_statistics.items():
@@ -89,8 +94,11 @@ def close_plan(plan: Plan):
     Use find_plan in combination with this function when admin requests for a plan to be closed.
     Inputted plan will be changed to read-only by changing the __is_closed flag in Plan class.
     """
-    plan.close()
-    plan.save()
+    if plan.is_closed:
+        raise controller_error.ControllerError("Plan is already closed.")
+    else:
+        plan.close()
+        plan.save()
 
 
 def find_camp(plan: Plan, camp_name: str) -> Camp:

--- a/controller/refugee_controller.py
+++ b/controller/refugee_controller.py
@@ -25,19 +25,22 @@ def create_refugee(firstname: str,
     """
     Function to create and save refugee data.
     """
-    try:
-        new_refugee = Refugee(firstname=firstname,
-                              lastname=lastname,
-                              num_of_family_member=num_of_family_member,
-                              starting_date=starting_date,
-                              medical_condition_type=medical_condition_type)
-        camp.refugees.add(new_refugee)
-        return new_refugee
-    except (Refugee.InvalidNameException,
-            Refugee.InvalidNumOfFamilyMemberException,
-            Refugee.InvalidStartingDateException,
-            Refugee.InvalidCampException) as e:
-        raise ControllerError(str(e))
+    if camp.plan.is_closed:
+        raise ControllerError(f"Plan {camp.plan.name} is closed. Please choose another plan.")
+    else:
+        try:
+            new_refugee = Refugee(firstname=firstname,
+                                  lastname=lastname,
+                                  num_of_family_member=num_of_family_member,
+                                  starting_date=starting_date,
+                                  medical_condition_type=medical_condition_type)
+            camp.refugees.add(new_refugee)
+            return new_refugee
+        except (Refugee.InvalidNameException,
+                Refugee.InvalidNumOfFamilyMemberException,
+                Refugee.InvalidStartingDateException,
+                Refugee.InvalidCampException) as e:
+            raise ControllerError(str(e))
 
 
 def find_refugee(refugee_id: int) -> Refugee:

--- a/controller/refugee_controller.py
+++ b/controller/refugee_controller.py
@@ -27,20 +27,19 @@ def create_refugee(firstname: str,
     """
     if camp.plan.is_closed:
         raise ControllerError(f"Plan {camp.plan.name} is closed. Please choose another plan.")
-    else:
-        try:
-            new_refugee = Refugee(firstname=firstname,
-                                  lastname=lastname,
-                                  num_of_family_member=num_of_family_member,
-                                  starting_date=starting_date,
-                                  medical_condition_type=medical_condition_type)
-            camp.refugees.add(new_refugee)
-            return new_refugee
-        except (Refugee.InvalidNameException,
-                Refugee.InvalidNumOfFamilyMemberException,
-                Refugee.InvalidStartingDateException,
-                Refugee.InvalidCampException) as e:
-            raise ControllerError(str(e))
+    try:
+        new_refugee = Refugee(firstname=firstname,
+                              lastname=lastname,
+                              num_of_family_member=num_of_family_member,
+                              starting_date=starting_date,
+                              medical_condition_type=medical_condition_type)
+        camp.refugees.add(new_refugee)
+        return new_refugee
+    except (Refugee.InvalidNameException,
+            Refugee.InvalidNumOfFamilyMemberException,
+            Refugee.InvalidStartingDateException,
+            Refugee.InvalidCampException) as e:
+        raise ControllerError(str(e))
 
 
 def find_refugee(refugee_id: int) -> Refugee:

--- a/controller/tests/test_refugee_controller.py
+++ b/controller/tests/test_refugee_controller.py
@@ -4,7 +4,6 @@ from models.camp import Camp
 from models.plan import Plan
 from models.refugee import Refugee
 import controller.refugee_controller as rc
-import controller.plan_controller as pc
 
 
 class RefugeeControllerTest(unittest.TestCase):
@@ -36,7 +35,7 @@ class RefugeeControllerTest(unittest.TestCase):
                     description='Test emergency plan',
                     geographical_area='London',
                     camps=[test_camp])
-        pc.close_plan(plan)
+        plan.close()
         with self.assertRaises(rc.ControllerError):
             rc.create_refugee("James", "Bond", test_camp, 6, date(2020, 1, 1),
                               [Refugee.MedicalCondition.HIV, Refugee.MedicalCondition.CANCER])

--- a/controller/tests/test_refugee_controller.py
+++ b/controller/tests/test_refugee_controller.py
@@ -4,6 +4,7 @@ from models.camp import Camp
 from models.plan import Plan
 from models.refugee import Refugee
 import controller.refugee_controller as rc
+import controller.plan_controller as pc
 
 
 class RefugeeControllerTest(unittest.TestCase):
@@ -27,6 +28,18 @@ class RefugeeControllerTest(unittest.TestCase):
         new_refugee = rc.create_refugee("James", "Bond", test_camp, 6, date(2020, 1, 1),
                                         [Refugee.MedicalCondition.HIV, Refugee.MedicalCondition.CANCER])
         self.assertIsInstance(new_refugee, Refugee)
+
+    def test_create_refugee_closed_plan(self):
+        test_camp = Camp(name='camp1')
+        plan = Plan(name='test_plan',
+                    emergency_type=Plan.EmergencyType.EARTHQUAKE,
+                    description='Test emergency plan',
+                    geographical_area='London',
+                    camps=[test_camp])
+        pc.close_plan(plan)
+        with self.assertRaises(rc.ControllerError):
+            rc.create_refugee("James", "Bond", test_camp, 6, date(2020, 1, 1),
+                              [Refugee.MedicalCondition.HIV, Refugee.MedicalCondition.CANCER])
 
     def test_find_and_return_refugee(self):
         """

--- a/controller/tests/test_volunteer_controller.py
+++ b/controller/tests/test_volunteer_controller.py
@@ -3,7 +3,6 @@ import controller.volunteer_controller as vc
 from models.plan import Plan
 from models.camp import Camp
 from models.volunteer import Volunteer
-import controller.plan_controller as pc
 
 
 class TestVolunteerController(unittest.TestCase):
@@ -40,7 +39,7 @@ class TestVolunteerController(unittest.TestCase):
                     description='Test',
                     geographical_area='',
                     camps=[camp_4])
-        pc.close_plan(plan)
+        plan.close()
         camp = Plan.find(key='Plan-3').camps.get('Camp-4')
         with self.assertRaises(vc.ControllerError):
             vc.create_volunteer(username='den', password='root', firstname='Dennis', lastname='Yung',
@@ -173,7 +172,7 @@ class TestVolunteerController(unittest.TestCase):
                     description='Test',
                     geographical_area='',
                     camps=[camp_4])
-        pc.close_plan(plan)
+        plan.close()
         camp = Plan.find(key='Plan-3').camps.get('Camp-4')
         with self.assertRaises(vc.ControllerError):
             vc.edit_camp(volunteer=volunteer, camp=camp, is_admin=True)

--- a/controller/tests/test_volunteer_controller.py
+++ b/controller/tests/test_volunteer_controller.py
@@ -3,6 +3,7 @@ import controller.volunteer_controller as vc
 from models.plan import Plan
 from models.camp import Camp
 from models.volunteer import Volunteer
+import controller.plan_controller as pc
 
 
 class TestVolunteerController(unittest.TestCase):
@@ -31,6 +32,19 @@ class TestVolunteerController(unittest.TestCase):
         volunteer = vc.create_volunteer(username='dennis', password='root', firstname='Dennis', lastname='Yung',
                                         phone='+447519953189', camp=camp)
         self.assertIsInstance(volunteer, Volunteer)
+
+    def test_create_volunteer_closed_plan(self):
+        camp_4 = Camp(name='Camp-4')
+        plan = Plan(name='Plan-3',
+                    emergency_type=Plan.EmergencyType.EARTHQUAKE,
+                    description='Test',
+                    geographical_area='',
+                    camps=[camp_4])
+        pc.close_plan(plan)
+        camp = Plan.find(key='Plan-3').camps.get('Camp-4')
+        with self.assertRaises(vc.ControllerError):
+            vc.create_volunteer(username='den', password='root', firstname='Dennis', lastname='Yung',
+                                phone='+447519953189', camp=camp)
 
     def test_create_volunteer_invalid_username(self):
         camp = Plan.find(key='Plan-1').camps.get('Camp-1')
@@ -150,6 +164,19 @@ class TestVolunteerController(unittest.TestCase):
         camp = Plan.find(key='Plan-1').camps.get('Camp-2')
         volunteer = vc.edit_camp(volunteer=volunteer, camp=camp, is_admin=False)
         self.assertEqual(str(volunteer.camp), 'Camp-2')
+
+    def test_edit_camp_closed_plan(self):
+        volunteer = Volunteer.find('yunsy')
+        camp_4 = Camp(name='Camp-4')
+        plan = Plan(name='Plan-3',
+                    emergency_type=Plan.EmergencyType.EARTHQUAKE,
+                    description='Test',
+                    geographical_area='',
+                    camps=[camp_4])
+        pc.close_plan(plan)
+        camp = Plan.find(key='Plan-3').camps.get('Camp-4')
+        with self.assertRaises(vc.ControllerError):
+            vc.edit_camp(volunteer=volunteer, camp=camp, is_admin=True)
 
     def test_edit_camp_under_different_plan_by_volunteer(self):
         volunteer = Volunteer.find('yunsy')

--- a/controller/volunteer_controller.py
+++ b/controller/volunteer_controller.py
@@ -12,7 +12,7 @@ def create_volunteer(username: str,
                      phone: str,
                      camp: Camp) -> Volunteer:
     if camp.plan.is_closed:
-        raise ControllerError(f"Plan {camp.plan.name} is closed. Please choose another plan.")
+        raise ControllerError(f"Plan {camp.plan.name} is closed.")
     try:
         volunteer = Volunteer(username=username, password=password, firstname=firstname, lastname=lastname,
                               phone=phone)
@@ -73,7 +73,7 @@ def edit_phone(volunteer: Volunteer, phone: str) -> Volunteer:
 def edit_camp(volunteer: Volunteer, camp: Camp, is_admin: bool) -> Volunteer:
     old_camp = volunteer.camp
     if camp.plan.is_closed:
-        raise ControllerError(f"Plan {camp.plan.name} is closed. Please choose another plan.")
+        raise ControllerError(f"Plan {camp.plan.name} is closed.")
     if is_admin:
         old_camp.volunteers.remove(volunteer)
         old_camp.save()

--- a/models/plan.py
+++ b/models/plan.py
@@ -86,7 +86,13 @@ class Plan(IndexedDocument):
         return self.__start_date  # Name mangling to access private field
 
     def __str__(self):
-        return f"Plan '{self.name}'"
+        if self.__is_closed:
+            return f"Plan: '{self.name}' (closed)\n" \
+                   f"Emergency Type: '{self.emergency.value.capitalize()}'\n" \
+                   f"Close Date: '{self.__close_date}'"
+        else:
+            return f"Plan '{self.name}'\n" \
+                   f"Emergency Type: '{self.emergency.value.capitalize()}'\n"
 
     def open_camps(self, *camps: Camp) -> None:
         """

--- a/models/tests/test_plan.py
+++ b/models/tests/test_plan.py
@@ -23,7 +23,7 @@ class PlanTest(unittest.TestCase):
                     description='Test emergency plan',
                     geographical_area='',
                     camps=[Camp(name='TestCamp')])
-        self.assertEqual("Plan 'My Plan'", str(plan))
+        self.assertEqual("Plan 'My Plan'\nEmergency Type: 'Earthquake'\n", str(plan))
 
     def test_missing_camps(self):
         """


### PR DESCRIPTION
### Changes made to: 
plan.py
test_plan.py
plan_controller.py
test_plan_controller.py
refugee_controller.py
test_refugee_controller.py
volunteer_controller.py
test_volunteer_controller.py

### In plan: 
Changed the str that it displays the plan name, whether it is closed or not, the close date if it is closed and the emergency type.
The test_plan has changed so that the first test runs successfully. 

### In plan_controller: 
Error handling for close_plan (should not be able to close a plan that is already closed). 
In test_plan_controller tested the exception handling. 

### In refugee_controller: 
Error handling for assigning refugees (should not be able to assign a refugee to a closed plan). 
In test_refugee_controller tested the exception handling.

### In volunteer_controller:
Error handling for assigning volunteers and editing camps (should not be able to assign a volunteer to a closed plan). 
In test_volunteer_controller tested the exception handling.

closes #49 